### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
   build:
     needs: comprehensive-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches: [main, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/3](https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `build` job in the workflow file. This block should specify the minimal permissions required for the job to function correctly. Since the `build` job does not appear to require write access, the permissions can be set to `contents: read`. This ensures that the job has only read access to the repository contents, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
