### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/comprehensive-test.yml
+++ b/.github/workflows/comprehensive-test.yml
@@ -1,4 +1,6 @@
 name: Comprehensive Test
+permissions:
+  contents: read
 on:
   workflow_call:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/4](https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required. Based on the workflow's operations, the `contents: read` permission is sufficient, as the workflow does not perform any write operations on the repository.

The `permissions` block should be added immediately after the `name` field at the top of the file. This ensures that all jobs in the workflow inherit the specified permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
