### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ env:
 jobs:
   # Run comprehensive tests first
   comprehensive-test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/comprehensive-test.yml
     secrets: inherit
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/2](https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the `comprehensive-test` job in the `.github/workflows/release.yml` file. This block should specify the minimal permissions required for the job. If the reusable workflow requires additional permissions, they can be added explicitly. For now, we will assume the minimal permissions of `contents: read` as a starting point.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
