### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,10 @@ jobs:
     needs: [build, docker]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/5](https://github.com/oszuidwest/zwfm-aeronapi/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `release` job. This block should specify the minimal permissions required for the job to function correctly. Based on the actions used in the `release` job, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `packages: write` for interacting with GitHub Packages.
- `id-token: write` for authentication purposes.

The `permissions` block should be added directly under the `release` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
